### PR TITLE
Change Return to Event

### DIFF
--- a/Nick.sol
+++ b/Nick.sol
@@ -6,9 +6,9 @@ contract Nick {
   mapping (bytes32 => address) public nickname;
 //stores information if address already has a nickname
   mapping (address => bool) public hasnick;
-
-//return value for UI, because storeNick and deleteNick don't return values (?)
-  string returnValue;
+  
+//allows web3 to watch for events  
+  event RegisterEvent(string outcome);
 
 //check if Nickname can be stored, if conditions are met, store Nickname
   function storeNick(bytes32 nick) {
@@ -16,12 +16,12 @@ contract Nick {
       if (hasnick[msg.sender] == false) {
         nickname[nick]=msg.sender;
         hasnick[msg.sender]=true;
-        returnValue="success";
+        RegisterEvent("success");
       } else {
-        returnValue="has_nick";
+        RegisterEvent("has_nick");
       }
     } else {
-      returnValue="nick_occupied";
+      RegisterEvent("nick_occupied");
     }
   }
 
@@ -29,23 +29,19 @@ contract Nick {
   function deleteNick(bytes32 nick) {
     if (nickname[nick] != msg.sender) {
       if (nickname[nick] == 0) {
-        returnValue="nick_vacant";
+        RegisterEvent("nick_vacant");
       } else {
-        returnValue="auth_error";
+        RegisterEvent("auth_error");
       }
     } else {
       nickname[nick]=0;
       hasnick[msg.sender]=false;
-      returnValue="success";
+      RegisterEvent("success");
     }
   }
 
 //Function to get address from a Nickname
   function checkNick(bytes32 nick) constant returns (address) {
     return nickname[nick];
-  }
-
-  function getReturnValue() constant returns (string) {
-    return returnValue;
   }
 }


### PR DESCRIPTION
This allows for more efficient watching of the blockchain with Web3 (this also is cheaper in terms of gas cost, as there is no storage - just event generation). 

Note, this will require the Dapp front end to be rewritten, but it should simplify things. More can be found here: https://ethereum.stackexchange.com/questions/2024/how-to-access-the-event-log-by-knowing-the-contract-address-web3